### PR TITLE
DIGITAL order fulfillment type

### DIFF
--- a/squareup/src/models/enums/order_fulfillment_type.rs
+++ b/squareup/src/models/enums/order_fulfillment_type.rs
@@ -12,4 +12,6 @@ pub enum OrderFulfillmentType {
     Shipment,
     /// A courier to deliver the fulfillment.
     Delivery,
+    /// A digital order of intangible product
+    Digital,
 }


### PR DESCRIPTION
This is in order to fix a bug detailed in this comment: 

https://github.com/kcable194/squareup/pull/2\#issuecomment-1963383132

tl;dr - Though it is not in the documentation, `DIGITAL` order fulfillment type is something returned by Square's API and causes a crash because it is not in the library currently when attempting to deserialize.

Read the aforementionned comment attentively to understand the implications of this pull request.